### PR TITLE
Added extend self to Helpers module

### DIFF
--- a/lib/url2png/helpers/common.rb
+++ b/lib/url2png/helpers/common.rb
@@ -1,7 +1,8 @@
 module Url2png
   module Helpers
     module Common
-      
+      extend self
+
       # complete image tag
       def site_image_tag url, options = {}
         # parse size


### PR DESCRIPTION
I wanted to be able to use the helpers in a Resque job without including the entire module. The way I use it is

```
Url2png::Helpers::Common.site_image_url(url, :browser_size => AppConfig.thumbnails[:browser_size], :size => AppConfig.thumbnails[:size])
```

Just a small change to make the helpers a bit more helpful :)
