### PR TITLE
Make sure protocol gets passed to site_image_url

### DIFF
--- a/lib/url2png/config.rb
+++ b/lib/url2png/config.rb
@@ -7,7 +7,7 @@ module Url2png
     
     def self.mode= mode
       raise "Url2png error: Invalid mode, only #{ MODES.join(', ') } are allowed" unless MODES.include?(mode.to_s)
-      @url2png_mode ||= mode.to_s
+      @url2png_mode = mode.to_s
     end
     
     def self.mode
@@ -15,8 +15,16 @@ module Url2png
     end
     
     # api settings
-    def self.api_url protocol
-      @url2png_url ||= "#{ protocol }api.url2png.com"
+    def self.api_url
+      "#{ api_protocol }api.url2png.com"
+    end
+
+    def self.api_protocol
+      @url2png_protocol ||= '//'
+    end
+
+    def self.api_protocol= protocol
+      @url2png_protocol = protocol
     end
 
     def self.api_version
@@ -26,7 +34,7 @@ module Url2png
     # public key setter and getter
     def self.public_key= key
       raise 'Url2png error: Invalid public key!' unless key.match(/^P/)
-      @url2png_key ||= key
+      @url2png_key = key
     end
 
     def self.public_key
@@ -37,7 +45,7 @@ module Url2png
     # shared secret setter and getter
     def self.shared_secret= secret
       raise 'Url2png error: Invalid shared secret!' unless secret.match(/^S/)
-      @url2png_secret ||= secret
+      @url2png_secret = secret
     end
 
     def self.shared_secret
@@ -47,7 +55,7 @@ module Url2png
 
     # size
     def self.default_size= size
-      @url2png_size ||= size
+      @url2png_size = size
     end
 
     def self.default_size

--- a/spec/helpers/common_rspec.rb
+++ b/spec/helpers/common_rspec.rb
@@ -7,32 +7,40 @@ describe Url2png do
     Url2png::Config.public_key = "P4DBEC0200EE98"
     Url2png::Config.shared_secret = "S169B0E051EAC6794B3EC9F385866187R"
   end
-  
+
   describe "site_image_tag" do
     it "should return the url of the http://pasparout.com image" do
       site_image_tag('http://pasparout.com').should_not be_nil
     end
   end
-  
+
   describe "site_image_url" do
+    it "should prefix the image url with fallback protocol" do
+      site_image_url('http://www.nytimes.com/').should =~ %r{^\/\/}
+    end
+
     it "should encode the thumbnail size when provided" do
       site_image_url('http://www.nytimes.com/', :thumbnail => '200x300').should =~ %r{t200x300}
     end
-    
+
     it "should encode the initial browser size when provided" do
       site_image_url('http://www.nytimes.com/', :browser_size => '200x300').should =~ %r{s200x300}
     end
-    
+
     it "should encode the delay when provided" do
       site_image_url('http://www.nytimes.com/', :delay => 3).should =~ %r{d3}
     end
-    
+
     it "should encode the fullscreen capture flag when provided" do
       site_image_url('http://www.nytimes.com/', :fullscreen => true).should =~ %r{FULL}
     end
 
     it "should concatenate options by using hyphens" do
       site_image_url('http://www.nytimes.com/', :delay => 3, :fullscreen => true).should =~ %r{d3-FULL}
+    end
+
+    it "should have custom protocol prefix for the image url" do
+      site_image_url('http://www.nytimes.com/', :protocol => 'https://').should =~ %r{https:\/\/}
     end
   end
 end


### PR DESCRIPTION
- Protocol would not get passed down to `site_image_url`
- Once protocol was set in an initializer, the config option would be ignored later if you tried to set it because of `||=`
- Don't have setters ignore input if instance variable was already set. Similar to above, was using `||=`
- Added new API option for protocol
- Falls back to // for protocol if non passed, will work for both https:// and http:// depending on the domain the page is on.
- html_safe isn't present without active_support
