### PR TITLE
Add missing options to helper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,6 @@ source "http://rubygems.org"
 group :development do
   gem "rspec", "~> 2.11.0"
   gem "jeweler", "~> 1.8.3"
-  gem "rcov", ">= 0"
+  gem "rake", "~> 10.0"
+  gem "simplecov"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,48 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
+    builder (3.2.2)
     diff-lcs (1.1.3)
-    git (1.2.5)
-    jeweler (1.8.3)
+    docile (1.1.5)
+    faraday (0.8.11)
+      multipart-post (~> 1.2.0)
+    git (1.3.0)
+    github_api (0.10.1)
+      addressable
+      faraday (~> 0.8.1)
+      hashie (>= 1.2)
+      multi_json (~> 1.4)
+      nokogiri (~> 1.5.2)
+      oauth2
+    hashie (3.4.6)
+    highline (1.7.8)
+    jeweler (1.8.8)
+      builder
       bundler (~> 1.0)
       git (>= 1.2.5)
+      github_api (= 0.10.1)
+      highline (>= 1.6.15)
+      nokogiri (= 1.5.10)
       rake
-    rake (0.9.2.2)
-    rcov (0.9.9)
+      rdoc
+    json (2.0.3)
+    jwt (1.5.6)
+    multi_json (1.12.1)
+    multi_xml (0.6.0)
+    multipart-post (1.2.0)
+    nokogiri (1.5.10)
+    oauth2 (1.3.0)
+      faraday (>= 0.8, < 0.11)
+      jwt (~> 1.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
+    public_suffix (2.0.5)
+    rack (2.0.1)
+    rake (10.5.0)
+    rdoc (5.0.0)
     rspec (2.11.0)
       rspec-core (~> 2.11.0)
       rspec-expectations (~> 2.11.0)
@@ -17,11 +51,20 @@ GEM
     rspec-expectations (2.11.3)
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.11.3)
+    simplecov (0.12.0)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   jeweler (~> 1.8.3)
-  rcov
+  rake (~> 10.0)
   rspec (~> 2.11.0)
+  simplecov
+
+BUNDLED WITH
+   1.13.6

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require 'rubygems'
 require 'bundler'
+
 begin
   Bundler.setup(:default, :development)
 rescue Bundler::BundlerError => e
@@ -7,9 +8,11 @@ rescue Bundler::BundlerError => e
   $stderr.puts "Run `bundle install` to install missing gems"
   exit e.status_code
 end
+
 require 'rake'
 
 require 'jeweler'
+
 Jeweler::Tasks.new do |gem|
   # gem is a Gem::Specification... see http://docs.rubygems.org/read/chapter/20 for more options
   gem.name = "url2png"
@@ -21,7 +24,6 @@ Jeweler::Tasks.new do |gem|
   gem.authors = ["robinhoudmeyers", "wout fierens", "fuzzyalej", "ceritium", "lukemelia"]
   # Include your dependencies below. Runtime dependencies are required when using your gem,
   # and development dependencies are only needed for development (ie running rake tasks, tests, etc)
-  #  gem.add_runtime_dependency 'jabber4r', '> 0.1'
   
   gem.add_development_dependency 'rspec', '> 2.6.0'
 end
@@ -29,13 +31,9 @@ Jeweler::RubygemsDotOrgTasks.new
 
 require 'rspec/core'
 require 'rspec/core/rake_task'
+
 RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.pattern = FileList['spec/**/*_spec.rb']
-end
-
-RSpec::Core::RakeTask.new(:rcov) do |spec|
-  spec.pattern = 'spec/**/*_spec.rb'
-  spec.rcov = true
 end
 
 task :default => :spec

--- a/lib/url2png/helpers/common.rb
+++ b/lib/url2png/helpers/common.rb
@@ -120,7 +120,7 @@ module Url2png
             ######
 
             # check for unavailable options
-            options_available = [:size, :thumbnail, :browser_size, :delay, :fullscreen, :unique, :user_agent]
+            options_available = [:size, :thumbnail, :browser_size, :delay, :fullscreen]
             options = check_options(options, options_available)
 
             # escape the url

--- a/lib/url2png/helpers/common.rb
+++ b/lib/url2png/helpers/common.rb
@@ -75,7 +75,7 @@ module Url2png
 
             # check for unavailable options
             options_alias = [:max_width, :max_height]
-            options_available = [:delay, :force, :fullpage, :thumbnail_max_width, :thumbnail_max_height, :viewport, :format]
+            options_available = [:custom_css_url, :delay, :force, :format, :fullpage, :say_cheese, :thumbnail_max_height, :thumbnail_max_width, :ttl, :unique, :user_agent, :viewport] 
 
             # assign alias to valid option
             options_alias.each do |key|
@@ -120,7 +120,7 @@ module Url2png
             ######
 
             # check for unavailable options
-            options_available = [:size, :thumbnail, :browser_size, :delay, :fullscreen]
+            options_available = [:size, :thumbnail, :browser_size, :delay, :fullscreen, :unique, :user_agent]
             options = check_options(options, options_available)
 
             # escape the url

--- a/lib/url2png/helpers/common.rb
+++ b/lib/url2png/helpers/common.rb
@@ -75,7 +75,7 @@ module Url2png
 
             # check for unavailable options
             options_alias = [:max_width, :max_height]
-            options_available = [:custom_css_url, :delay, :force, :format, :fullpage, :say_cheese, :thumbnail_max_height, :thumbnail_max_width, :ttl, :unique, :user_agent, :viewport] 
+            options_available = [:accept_languages, :custom_css_url, :delay, :force, :format, :fullpage, :say_cheese, :thumbnail_max_height, :thumbnail_max_width, :ttl, :unique, :user_agent, :viewport] 
 
             # assign alias to valid option
             options_alias.each do |key|

--- a/spec/helpers/common_spec.rb
+++ b/spec/helpers/common_spec.rb
@@ -17,6 +17,26 @@ describe Url2png do
   end
 
   describe "site_image_url" do
+    it "should allow unique" do
+      site_image_url('http://www.nytimes.com/', unique: 'unique').should =~ %r{unique=unique}
+    end
+
+    it "should allow custom_css_url" do
+      site_image_url('http://www.nytimes.com/', custom_css_url: 'http://random.com/random.css').should =~ %r{custom_css_url}
+    end
+
+    it "should allow user_agent" do
+      site_image_url('http://www.nytimes.com/', user_agent: 'ua').should =~ %r{user_agent=ua}
+    end
+
+    it "should allow say_cheese" do
+      site_image_url('http://www.nytimes.com/', say_cheese: 'true').should =~ %r{say_cheese=true}
+    end
+
+    it "should allow ttl" do
+      site_image_url('http://www.nytimes.com/', ttl: 'ttl').should =~ %r{ttl=ttl}
+    end
+
     it "should encode the thumbnail max width when provided" do
       site_image_url('http://www.nytimes.com/', :thumbnail_max_width => '200').should =~ %r{thumbnail_max_width=200}
     end

--- a/spec/helpers/common_spec.rb
+++ b/spec/helpers/common_spec.rb
@@ -21,6 +21,10 @@ describe Url2png do
       site_image_url('http://www.nytimes.com/', unique: 'unique').should =~ %r{unique=unique}
     end
 
+    it "should allow unique" do
+      site_image_url('http://www.nytimes.com/', accept_languages: 'de').should =~ %r{accept_languages=de}
+    end
+
     it "should allow custom_css_url" do
       site_image_url('http://www.nytimes.com/', custom_css_url: 'http://random.com/random.css').should =~ %r{custom_css_url}
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,9 @@
+require 'simplecov'
+SimpleCov.start
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'rspec'
 require 'url2png'
-
 # Requires supporting files with custom matchers and macros, etc,
 # in ./support/ and its subdirectories.
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
@@ -12,3 +13,4 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.alias_example_to :fit, :focused => true
 end
+


### PR DESCRIPTION
Hello there. As I saw in #22 you suggested that someone write a PR to fix the problem.

This adds unique to the available options as well as adds user_agent, say_cheese, ttl, and custom_css_url which are all part of the url2png api.

Thank you for taking your time to look at this and get this merged.

I had to make some changes to get this to work on ruby 2 since it was relying on Rcov which won't work on anything that is > 1.9.x