### PR TITLE
Fix url for 'placehold' mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This is done by setting the mode:
 Options are:
 
 * production (default; will use the url2png api to generate images)
-* placehold (will generate images at http://placehold.it)
+* placehold (will generate images at http://via.placeholder.com)
 * dummy (will give a grey base64 data image)
 
 #### default_size

--- a/lib/url2png/helpers/common.rb
+++ b/lib/url2png/helpers/common.rb
@@ -62,7 +62,7 @@ module Url2png
           fPjwfwYgYAIRIAAAMrgDTJyW2igAAAAASUVORK5CYII='.gsub(/\n/,'')
 
         when 'placehold'
-          "http://placehold.it/#{ dim[:size] }"
+          "http://via.placeholder.com/#{ dim[:size] }"
 
         else
           # build parameters portion of URL


### PR DESCRIPTION
`placehold.it` now hosts their images on `via.placeholder.com`
- [How to use Placeholders](https://placeholder.com/#How-To-Use-Our-Placeholders)